### PR TITLE
Correct the SSE41 definition

### DIFF
--- a/benchmarks/bulk-insert-and-query.cc
+++ b/benchmarks/bulk-insert-and-query.cc
@@ -382,7 +382,7 @@ int main(int argc, char * argv[]) {
     {52, "BlockedBloom-addAll"},
     {53, "BlockedBloom64"},
 #endif
-#ifdef __SSE41__
+#ifdef __SSE4_1__
     {54, "BlockedBloom16"},
 #endif
 
@@ -895,7 +895,7 @@ int main(int argc, char * argv[]) {
       cout << setw(NAME_WIDTH) << names[a] << cf << endl;
   }
 #endif
-#ifdef __SSE41__
+#ifdef __SSE4_1__
   a = 54;
   if (algorithmId == a || (algos.find(a) != algos.end())) {
       auto cf = FilterBenchmark<SimdBlockFilterFixed16<SimpleMixSplit>>(

--- a/benchmarks/filterapi.h
+++ b/benchmarks/filterapi.h
@@ -473,7 +473,7 @@ template <typename filterTable> struct FilterAPI<Prefix_Filter<filterTable>> {
 
 #endif
 
-#ifdef __SSE41__
+#ifdef __SSE4_1__
 template <typename HashFamily>
 struct FilterAPI<SimdBlockFilterFixed16<HashFamily>> {
   using Table = SimdBlockFilterFixed16<HashFamily>;

--- a/src/bloom/simd-block-fixed-fpp.h
+++ b/src/bloom/simd-block-fixed-fpp.h
@@ -398,7 +398,7 @@ SimdBlockFilterFixed<HashFamily>::Find(const uint64_t key) const noexcept {
 /// 16-byte version (not very good)
 ///////////////////////////////////////////////////////////////////
 
-#ifdef __SSE41__
+#ifdef __SSE4_1__
 
 #include <smmintrin.h>
 
@@ -485,4 +485,4 @@ SimdBlockFilterFixed16<HashFamily>::Find(const uint64_t key) const noexcept {
   return _mm_testc_si128(bucketvalue,mask);
 }
 
-#endif // #ifdef __SSE41__
+#endif // #ifdef __SSE4_1__


### PR DESCRIPTION
GCC generates the following definitions:

```
$ gcc -msse4 -dM -E - < /dev/null | egrep "SSE" | sort
#define __MMX_WITH_SSE__ 1
#define __SSE2_MATH__ 1
#define __SSE2__ 1
#define __SSE3__ 1
#define __SSE4_1__ 1
#define __SSE4_2__ 1
#define __SSE_MATH__ 1
#define __SSE__ 1
#define __SSSE3__ 1
```

However, several places in the FastFilter source code use `__SSE41__`. There is a missing underscore.  This PR fixes the ifdef to match the ones from GCC. Output is from GCC version 11.4.0.